### PR TITLE
chore:)Revert broken update docker base image (DEV-3957)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /dsp-meta
 COPY . .
 RUN cd web-frontend && yarn install && yarn run build
 
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 # add data
 COPY ./data /data
 


### PR DESCRIPTION
- **Revert "chore: Update dsp-meta base image to Debian Bullseye (DEV-3957) (#170)"**

Unfortunately the new base image is incompatible, when starting the server the following error message occurs:
```
dsp-meta-server: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by dsp-meta-server)
dsp-meta-server: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by dsp-meta-server)
dsp-meta-server: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by dsp-meta-server)
```