### PR TITLE
chore: Change release-please config

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -35,12 +35,16 @@
     }
   ],
   "plugins": [
-    "cargo-workspace",
     "sentence-case",
     {
+      "type": "cargo-workspace",
+      "merge": false
+    },
+    {
       "type": "linked-versions",
-      "groupName": "dsp-meta",
+      "groupName": "meta",
       "components": [
+        ".",
         "dsp-domain",
         "dsp-meta",
         "dsp-meta-cmd"


### PR DESCRIPTION
I'm not sure this will indeed help, but it's worth a try.  
Changes:

- add "merge false" to cargo-workspace plugin as instructed here: https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#linked-versions
- add the root package to the components to include in the group
- rename the group, so the names between component and group don't conflict