### PR TITLE
build: Use CARGO_VERSION for tagging released docker images instead of git tag (DEV-4076)

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ DOCKER_REPO := "daschswiss/dsp-meta"
 CARGO_VERSION := `cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[].version'`
 COMMIT_HASH := `git log --pretty=format:'%h' -n 1`
 GIT_TAG := `git describe --tags --exact-match 2>/dev/null || true`
-IMAGE_TAG := if GIT_TAG == "" { CARGO_VERSION + "-" + COMMIT_HASH } else { GIT_TAG }
+IMAGE_TAG := if GIT_TAG == "" { CARGO_VERSION + "-" + COMMIT_HASH } else { CARGO_VERSION }
 DOCKER_IMAGE := DOCKER_REPO + ":" + IMAGE_TAG
 
 # List all recipes


### PR DESCRIPTION
Current release was published as `daschswiss/dsp-meta:dsp-meta-v2.2.4` but it should be `daschswiss/dsp-meta:2.2.4`.