### PR TITLE
chore: improve  dependencies update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/web-frontend"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "build(deps)"
     groups:
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "build(deps)"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,32 @@
 
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: "/"
+  - package-ecosystem: "npm"
+    directory: "/web-frontend"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+       frontend-dependencies:
+          applies-to: version-updates
+          patterns:
+            - "*" 
+    ignore:
+      update-types: ["version-update:semver-major"]
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+       backend-dependencies:
+          applies-to: version-updates
+          patterns:
+            - "*" 
     ignore:
       # These are peer deps of Cargo and should not be automatically bumped
       - dependency-name: "semver"
       - dependency-name: "crates-io"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,9 +28,11 @@ updates:
        backend-dependencies:
           applies-to: version-updates
           patterns:
-            - "*" 
+            - "*"
     ignore:
       # These are peer deps of Cargo and should not be automatically bumped
       - dependency-name: "semver"
       - dependency-name: "crates-io"
+      # Ignore major updates for all dependencies
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
             - "*" 
     ignore:
       - dependency-name: "*"
-      update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
           patterns:
             - "*" 
     ignore:
+      - dependency-name: "*"
       update-types: ["version-update:semver-major"]
   - package-ecosystem: "cargo"
     directory: "/"


### PR DESCRIPTION
This is an attempt to group dependencies update and reduce number of Dependabot PRs.
Proposed setup should divide updates for two PRs, one fore frontend (npm), another for backend (Cargo), with exclusion of major updates, which should be done separately, due to most likely breaking changes.