### PR TITLE
data: Use relative paths to link data to schema

### DIFF
--- a/data/json/Rome.json
+++ b/data/json/Rome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Croci, C., Quadri, I, Gianandrea, M., Romano, S., Tosti, E., Chiaraella, M., Ventura, D., Rivoal, M., 2022, Rome in the Early Middle Ages: Arts and Culture [database] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0118",

--- a/data/json/aura-effizienz.json
+++ b/data/json/aura-effizienz.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Jael Bollag, Katharina Wolf, Hubert Thüring (2018-2023). Aura und Effizienz [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/0846.",

--- a/data/json/awg.json
+++ b/data/json/awg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "See https://www.anton-webern.ch/index.php?id=85",

--- a/data/json/beol.json
+++ b/data/json/beol.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Bernoulli-Euler Online (BEOL), 2019, DaSCH. https://beol.dasch.swiss",

--- a/data/json/beyondthetext.json
+++ b/data/json/beyondthetext.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Beyond the Text (BT), University of Basel, 2026",

--- a/data/json/big-data-in-agriculture.json
+++ b/data/json/big-data-in-agriculture.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Klauser FR and Pauschinger D (2020) Big Data in Agriculture: The Making of Smart Farms.",

--- a/data/json/biz.json
+++ b/data/json/biz.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Lucien Criblez, Lea Hägi, Stefan Kessler, Christina Rothen and Thomas Ruoss (2024). Forschungsinfrastruktur «Bildung in Zahlen» [Datenbank]. DaSCH, https://ark.dasch.swiss/ark:/72163/1/0828.",

--- a/data/json/bruno-manser.json
+++ b/data/json/bruno-manser.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Bruno Manser/Bruno Manser Fonds",

--- a/data/json/cache.json
+++ b/data/json/cache.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Gegen|Wissen, intercom: Zürich (2020)",

--- a/data/json/commode.json
+++ b/data/json/commode.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Canonicity, Obscenity, and the Making of Modern Chaucer (COMMode): An Investigation of the Transmission and Audiences of The Canterbury Tales from 1700 to 2020",

--- a/data/json/dasch.json
+++ b/data/json/dasch.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "DaSCH (2023). Swiss National Data and Service Center for the Humanities [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/0810",

--- a/data/json/decoso.json
+++ b/data/json/decoso.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "teaserText": "It aims to apply decolonial methods and to mobilize practice-based approaches to engage in the critical analysis of case studies of art practices from socialist geographies of the Cold War period.",

--- a/data/json/deir-el-medina.json
+++ b/data/json/deir-el-medina.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "status": "Ongoing",

--- a/data/json/delille.json
+++ b/data/json/delille.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Reconstruire Delille, 2021",

--- a/data/json/digitalagenda.json
+++ b/data/json/digitalagenda.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Guerrero Cantarell, Rosalía, Carmen Flury, Fabian Grütter and Michael Geiss (2023). Education and the European Digital Agenda: Switzerland, Germany and Sweden after 1970. DaSCH, https://ark.dasch.swiss/ark:/72163/1/0848.",

--- a/data/json/dokubib.json
+++ b/data/json/dokubib.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Dokumentationsbibliothek St. Moritz",

--- a/data/json/drawings.json
+++ b/data/json/drawings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Brandt, P.-Y., Serbaeva O.,  Cocco, Ch., Dessart, G., Dandarova Robert, Z., Rivoal, M.,  2019, Dessins de dieux [database] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0105.",

--- a/data/json/eHKKA.json
+++ b/data/json/eHKKA.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Morgenthaler et al., historisch-kritsche Kellerausgabe online, 1996-2013",

--- a/data/json/fagottino.json
+++ b/data/json/fagottino.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Agrell, Donna, Domínguez, Áurea, Graziadio, Giovanni Battista, Matthews, Zoë, Viola, Letizia, Plath, Niko, Simian, Ricardo (2023). Fagottino project research articles and documents [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/0845",

--- a/data/json/globalgeschichte.json
+++ b/data/json/globalgeschichte.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Marti, P., Studer, D., Affolter, S. (2024). Globalgeschichtliche Perspektiven im Schweizer Geschichtsunterricht [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/084A",

--- a/data/json/hdm.json
+++ b/data/json/hdm.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "HdM-Bern",

--- a/data/json/healing-arts.json
+++ b/data/json/healing-arts.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Holler, T.; Baptista Wilhelm, L; Von Kerssenbrock-Krosigk, G.: Healing Arts. Representations and Practices of Medical Knowledge in Art and Literature (9th-12th centuries) [database]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/083E",

--- a/data/json/igeoarchive.json
+++ b/data/json/igeoarchive.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Brönnimann, D., Lo Russo, S., Pümpin, Ch., Ismail-Meyer, K., Devos, Y., Kübler, S., Rentzel, Ph. (2024). I-GEOARCHive [Database]. DaSCH. http://ark.dasch.swiss/ark:/72163/1/0838",

--- a/data/json/incunabula.json
+++ b/data/json/incunabula.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "teaserText": "An art-scientific monograph of the richly illustrated early prints in Basel - the most important center of early letterpress printing in the territory of present-day Switzerland.",

--- a/data/json/kunsthalle.json
+++ b/data/json/kunsthalle.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Fotoarchiv Kunsthalle Basel (2023). [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/080C",

--- a/data/json/lenzburg.json
+++ b/data/json/lenzburg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Schweizerisches Volksliedarchiv, Tonbandsammlung Folkfestival auf der Lenzburg",

--- a/data/json/lhtt.json
+++ b/data/json/lhtt.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Life Histories of Theban Tombs (2023). DaSCH. https://ark.dasch.swiss/ark:/72163/1/0820",

--- a/data/json/limc.json
+++ b/data/json/limc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Digital LIMC (2021): Digital LIMC, DaSCH. https://weblimc.org/page/home/Basel",

--- a/data/json/locusludi.json
+++ b/data/json/locusludi.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Attia (2024). Kottabos in the Greek World (2024). DaSCH, https://ark.dasch.swiss/ark:/72163/1/0847.",

--- a/data/json/mark16.json
+++ b/data/json/mark16.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "SNSF MARK16 (2023). MARK16 Manuscript Data [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/0844.",

--- a/data/json/mfmps.json
+++ b/data/json/mfmps.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Terrier Aliferis, L., Acosta, L., Ciardo, S., Rivoal, M., 2020, MedFrameS [database] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0116.",

--- a/data/json/mls.json
+++ b/data/json/mls.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "AutorIn: Artikelname. MLS, Datum der Abfrage.",

--- a/data/json/nietzsche.json
+++ b/data/json/nietzsche.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "teaserText": "The digital edition project \"Der späte Nietzsche\" (The Late Nietzsche) publishes Friedrich Nietzsche's late estate digitally congruent to the manuscripts.",

--- a/data/json/olympic.json
+++ b/data/json/olympic.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Clastres, P., Carpentier, F., Klima, H., Défayes, F., Metzger, C., Rivoal, M., 2020, Les membres du Comité international olympique (CIO) de 1894 à 1972 [database]. DaSCH https://ark.dasch.swiss/ark:/72163/1/0114.",

--- a/data/json/operativetv.json
+++ b/data/json/operativetv.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Weber, Anne-Katrin; Cronjäger, Lisa; Sandoz, Marie; Scheiwiller, Sébastien (2024). Operative TV [Database]. DaSCH",

--- a/data/json/participation-social.json
+++ b/data/json/participation-social.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Obrist B, Dillip A, Mayumana I, Rutishauser M, Simon V (2022). Participation in Social Health Protection: An Anthropological Case Study in Tanzania [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/083D.",

--- a/data/json/portraits-pou.json
+++ b/data/json/portraits-pou.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Portraits of Unbelonging (POU), 2021, DaSCH. ark.dasch.swiss/ark:/72163/1/0827",

--- a/data/json/posepi.json
+++ b/data/json/posepi.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Jacquin, J., Keck, A., Robin, C., Roh, S., Rivoal, M. (2024). Marqueurs épistémiques et évidentiels du français identifiés et annotés dans un corpus d'interactions relevant de débats politiques et de réunions d’entreprise [Projet FNS 188924, POSEPI] [base de données] (DaSCH), http://ark.dasch.swiss/ark:/72163/1/0120",

--- a/data/json/postkarten.json
+++ b/data/json/postkarten.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Postkarten Russland (2023). [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/0811",

--- a/data/json/prethero.json
+++ b/data/json/prethero.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Wawrzyniak, N., Doudet, E., Rivoal, M., Premiers théâtres romands [base de données] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0119. Wawrzyniak, N., Doudet, E., Rivoal, M., Early French-Swiss Theater [database] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0119.",

--- a/data/json/prom_know.json
+++ b/data/json/prom_know.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "R. Sigrist, 2023, Base de données sur les savants de la période 1700-1870 [base de données], Swiss National Data and Service Center for the Humanities (DaSCH), http://ark.dasch.swiss/ark:/72163/1/0117.",

--- a/data/json/reforme-geneve.json
+++ b/data/json/reforme-geneve.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Grosse, Ch., Dunant Gonzenbach, A., Matthey-Doret, A., 2019, Côté chaire, côté rue, La Réforme à Genève (1517-1617) [database] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0111.",

--- a/data/json/religious-speech.json
+++ b/data/json/religious-speech.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "Gonzalez, Ph., Roca Escoda, M., Stavo Debauge, J., Evequoz, Y., Ben Amor, S., Rivoal, M., 2019, Embarras de la parole religieuse [base de données] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0101.",

--- a/data/json/rich.json
+++ b/data/json/rich.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Nitsche, M., Schobinger, J., Scheller, J., Thyroff, J., Weber, T. (2024). Historische Lernprozesse erforschen – Research of Learning Processes in History (RicH) [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/084E",

--- a/data/json/roud.json
+++ b/data/json/roud.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Maggetti, D., Jacquier Kaempfer, C., Spadini, E., Pellegrino, B., Burri, J., Lacord, R., Peterman, S., Christen, A., Jaouen, L., Rivoal, M., 2020, Gustave Roud, oeuvres [database] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0112.",

--- a/data/json/sgv.json
+++ b/data/json/sgv.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Photo Archive of the Cultural Anthropology Switzerland (CAS).",

--- a/data/json/societesavoie.json
+++ b/data/json/societesavoie.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Pibiri, E., Badoux, L., Frei, S., Rivoal, M., 2022, Base de données du projet Hôtels de la cour de Savoie [base de données], Swiss National Data and Service Center for the Humanities (DaSCH), http://ark.dasch.swiss/ark:/72163/1/0121.",

--- a/data/json/stardom.json
+++ b/data/json/stardom.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Boillat, A., Chedaleux, D., Rohner, J., Cordonier, L., Gaillard, A., Jaouen, L., Rivoal, M., 2018, Personnage et vedettariat au prisme du genre [database] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0107.",

--- a/data/json/tanner.json
+++ b/data/json/tanner.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Boillat, A., Annen, V, Modoux, J., Jaouen, L., Rivoal, M., 2022, « Le scénario chez Alain Tanner : discours et pratiques » [base de données] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0102.",

--- a/data/json/tdk.json
+++ b/data/json/tdk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "University of Basel Kings’ Valley Project Online (UBKVP), 2021, DaSCH. ark.dasch.swiss/ark:/72163/1/0805",

--- a/data/json/tds.json
+++ b/data/json/tds.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Ponzetto, V., Ruimi, J., Hodroge, A., Fièvre, P., Baumann, F., Hugentobler, Th., Schuwey, Ch., Rivoal, M., 2018, Théâtres de société [database] (DaSCH), https://ark.dasch.swiss/ark:/72163/1/0103.",

--- a/data/json/vitrocentre.json
+++ b/data/json/vitrocentre.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Vitrocentre Romont has to be mentioned, in regards to images: Vitrocentre Romont and where mentioned the photographer has to be mentioned",

--- a/data/json/waldaucinema.json
+++ b/data/json/waldaucinema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "Berton, M., Murtas, E., Tinguely, R., Rivoal, M., Jaouen, L., 2023, Cinéma et psychiatrie en Suisse : les collections Waldau [database] (DaSCH), http://ark.dasch.swiss/ark:/72163/1/0106.",

--- a/data/json/woposs.json
+++ b/data/json/woposs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-draft.json",
   "project": {
     "__type": "Project",
     "howToCite": "The WoPoss modality corpus. University of Neuchâtel. SNSF. Distributed by DaSCH.",

--- a/data/json/wordweb.json
+++ b/data/json/wordweb.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+  "$schema": "../../resources/schema-metadata-final.json",
   "project": {
     "__type": "Project",
     "howToCite": "WordWeb/IDEM (2021), DaSCH. ark.dasch.swiss/ark:/72163/1/0826",


### PR DESCRIPTION
Previously, the all data had a link to the old schema (in the archived `dsp-meta-svc` repo), but as this schema was no longer up to date, editors always complained about the data not being valid.

With this PR, the new schemas are being used.  
Additionally, I used relative links, as it seems to be more practical in most cases.