### PR TITLE
chore: Fix failing build because of yanked dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ dirs = "5.0.1" # provides platform-specific locations for storing user configura
 http-body-util = "0.1.0"
 indicatif = "0.17.8" # prograss bars and spinners
 log = "0.4.22" # logging facade
-once_cell = "1.20.0"
+once_cell = "1.19.0"
 pid1 = "0.1.1"
 serde = { version = "1", features = ["derive"] }
 serde_with = "3.9.0"


### PR DESCRIPTION
see https://crates.io/crates/once_cell/1.20.0