### PR TITLE
build: change output format to Universal Module Definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@
 /**/node_modules
 web-frontend/.yarn/install-state.gz
 
-
-
 # Added by cargo
 
 /target

--- a/web-frontend/rollup.config.js
+++ b/web-frontend/rollup.config.js
@@ -39,7 +39,7 @@ export default {
   input: 'src/main.ts',
   output: {
     sourcemap: true,
-    format: 'iife',
+    format: 'umd',
     name: 'app',
     file: 'public/build/bundle.js',
   },


### PR DESCRIPTION
It should make Rollup builder major update possible.