### PR TITLE
fix: Make Pagination work again by using default vaules for limit and page (DEV-4624)

### DIFF
--- a/src/api/handler/v1/projects/handlers.rs
+++ b/src/api/handler/v1/projects/handlers.rs
@@ -10,7 +10,7 @@ use crate::api::handler::v1::projects::responses::{
     ProjectMetadataDto, ProjectMetadataWithInfoDto,
 };
 use crate::app_state::AppState;
-use crate::domain::metadata_repository::{Filter, Pagination};
+use crate::domain::metadata_repository::{FilterAndQuery, Pagination};
 use crate::domain::model::draft_model::Shortcode;
 use crate::error::DspMetaError;
 
@@ -42,11 +42,11 @@ pub async fn get_by_shortcode(
 pub async fn get_by_page_and_filter(
     State(state): State<Arc<AppState>>,
     pagination: Query<Pagination>,
-    filter: Query<Filter>,
+    filter_and_query: Query<FilterAndQuery>,
 ) -> Result<Response, DspMetaError> {
     trace!("entered get_all_project_metadata()");
     let pagination = pagination.0;
-    let filter = filter.0;
+    let filter = filter_and_query.0;
     let page = state.metadata_service.find(&filter, &pagination)?;
     let mut response = Json(
         page.data

--- a/src/api/handler/v1/projects/handlers.rs
+++ b/src/api/handler/v1/projects/handlers.rs
@@ -10,7 +10,7 @@ use crate::api::handler::v1::projects::responses::{
     ProjectMetadataDto, ProjectMetadataWithInfoDto,
 };
 use crate::app_state::AppState;
-use crate::domain::metadata_repository::{OptionalFilter, OptionalPagination};
+use crate::domain::metadata_repository::{Filter, Pagination};
 use crate::domain::model::draft_model::Shortcode;
 use crate::error::DspMetaError;
 
@@ -41,12 +41,12 @@ pub async fn get_by_shortcode(
 #[axum_macros::debug_handler]
 pub async fn get_by_page_and_filter(
     State(state): State<Arc<AppState>>,
-    pagination: Query<OptionalPagination>,
-    filter: Query<OptionalFilter>,
+    pagination: Query<Pagination>,
+    filter: Query<Filter>,
 ) -> Result<Response, DspMetaError> {
     trace!("entered get_all_project_metadata()");
-    let pagination = pagination.0.or_default();
-    let filter = filter.0.or_default();
+    let pagination = pagination.0;
+    let filter = filter.0;
     let page = state.metadata_service.find(&filter, &pagination)?;
     let mut response = Json(
         page.data

--- a/src/api/handler/v1/projects/responses.rs
+++ b/src/api/handler/v1/projects/responses.rs
@@ -1,11 +1,11 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::domain::model::draft_model::{DraftMetadata, DraftProjectStatus};
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProjectMetadataDto(pub DraftMetadata);
 
 /// Convert `ProjectMetadataDto` into an Axum response.
@@ -20,7 +20,7 @@ impl IntoResponse for ProjectMetadataDto {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProjectMetadataWithInfoDto {
     id: String,
     name: String,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod convert;
-mod handler;
+pub mod handler;
 pub mod router;

--- a/src/domain/metadata_repository.rs
+++ b/src/domain/metadata_repository.rs
@@ -11,32 +11,19 @@ use crate::domain::model::draft_model::*;
 use crate::error::DspMetaError;
 use crate::infrastructure::load_json_file_paths;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default)]
 pub struct Pagination {
-    #[serde(rename = "_page")]
+    #[serde(rename = "_page", default = "default_page")]
     pub page: usize,
-    #[serde(rename = "_limit")]
+    #[serde(rename = "_limit", default = "default_limit")]
     pub limit: usize,
 }
-impl Default for Pagination {
-    fn default() -> Self {
-        Pagination {
-            page: 1,
-            limit: 100,
-        }
-    }
-}
 
-#[derive(Debug, Deserialize, Default, Clone)]
-pub struct OptionalPagination {
-    #[serde(flatten)]
-    pub pagination: Option<Pagination>,
+fn default_limit() -> usize {
+    25
 }
-
-impl OptionalPagination {
-    pub fn or_default(&self) -> Pagination {
-        self.pagination.clone().unwrap_or_default()
-    }
+fn default_page() -> usize {
+    1
 }
 
 #[derive(Deserialize, Default, Debug, Clone)]
@@ -45,18 +32,6 @@ pub struct Filter {
     pub query: Option<String>,
     #[serde(rename = "filter")]
     pub filter: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-pub struct OptionalFilter {
-    #[serde(flatten)]
-    pub filter: Option<Filter>,
-}
-
-impl OptionalFilter {
-    pub fn or_default(&self) -> Filter {
-        self.filter.clone().unwrap_or_default()
-    }
 }
 
 pub struct Page<T> {

--- a/src/domain/metadata_repository.rs
+++ b/src/domain/metadata_repository.rs
@@ -20,7 +20,7 @@ pub struct Pagination {
 }
 
 fn default_limit() -> usize {
-    25
+    100
 }
 fn default_page() -> usize {
     1

--- a/src/domain/metadata_service.rs
+++ b/src/domain/metadata_service.rs
@@ -1,6 +1,6 @@
 use tracing::{instrument, trace};
 
-use crate::domain::metadata_repository::{Filter, MetadataRepository, Page, Pagination};
+use crate::domain::metadata_repository::{FilterAndQuery, MetadataRepository, Page, Pagination};
 use crate::domain::model::draft_model::*;
 use crate::error::DspMetaError;
 
@@ -26,7 +26,7 @@ impl MetadataService {
     #[instrument(skip(self))]
     pub fn find(
         &self,
-        filter: &Filter,
+        filter: &FilterAndQuery,
         pagination: &Pagination,
     ) -> Result<Page<DraftMetadata>, DspMetaError> {
         self.repo.find(filter, pagination)

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -3,6 +3,7 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use api::handler::v1::projects::responses::ProjectMetadataWithInfoDto;
     use axum::http::StatusCode;
     use axum_test::TestServer;
     use chrono::NaiveDate;
@@ -11,7 +12,8 @@ mod tests {
     use dsp_meta::domain::metadata_repository::MetadataRepository;
     use dsp_meta::domain::metadata_service::MetadataService;
     use dsp_meta::domain::model::draft_model::{
-        DraftDate, DraftMetadata, DraftProject, DraftText, DraftTextOrUrl, Shortcode,
+        DraftDate, DraftMetadata, DraftProject, DraftProjectStatus, DraftText, DraftTextOrUrl,
+        Shortcode,
     };
     use fake::{Fake, Faker};
     use nonempty::NonEmpty;
@@ -174,12 +176,33 @@ mod tests {
         assert_eq!(response.status_code(), StatusCode::OK);
     }
 
+    #[tokio::test]
+    async fn projects_should_page() {
+        let data = (1..5)
+            .map(|i| format!("{:04}", i))
+            .map(|shortcode| test_data(&shortcode))
+            .collect::<Vec<_>>();
+
+        let server = build_server(data);
+
+        let response = server.get("/api/v1/projects?_page=1&_limit=2").await;
+
+        let json: Vec<ProjectMetadataWithInfoDto> = response.json();
+        assert_eq!(json.len(), 2);
+        response.assert_header("X-Total-Count", "4");
+        response.assert_status_ok();
+    }
+
     fn test_data(shortcode: &str) -> DraftMetadata {
+        test_data_with_status(shortcode, None)
+    }
+
+    fn test_data_with_status(shortcode: &str, status: Option<DraftProjectStatus>) -> DraftMetadata {
         let fake_name = Faker.fake::<String>();
         let expected: DraftMetadata = DraftMetadata {
             project: DraftProject {
                 shortcode: Shortcode::try_from(shortcode.to_string()).expect("Valid shortcode"),
-                status: None,
+                status,
                 name: fake_name,
                 description: None,
                 start_date: DraftDate(NaiveDate::default()),

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -134,10 +134,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn projects_should_return_empty_array_with_no_data_using_filter() {
+    async fn projects_should_return_empty_array_with_no_data_using_filter_none() {
         let server = build_server(vec![]);
 
-        let response = server.get("/api/v1/projects?q=foo&filter=bar").await;
+        let response = server.get("/api/v1/projects?filter=none").await;
 
         let resp_txt = response.text();
         let actual: Value = serde_json::from_str(&resp_txt).unwrap();
@@ -147,6 +147,13 @@ mod tests {
             panic!("Expected an array");
         }
         assert_eq!(response.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn invalid_filter_should_return_400() {
+        let server = build_server(vec![]);
+        let response = server.get("/api/v1/projects?filter=invalid").await;
+        response.assert_status_bad_request();
     }
 
     #[tokio::test]


### PR DESCRIPTION
Remove non working `OptionalPagination` and `OptionalFilter` and replace with default values for non present query parameters.

Ensure that the filter query parameter only accepts known values.

Add tokio test for paging.


Fixes regression introduces in https://github.com/dasch-swiss/dsp-meta/commit/ade9581b7c618321ebb4d3bbb9ce18ddf724be8f#diff-0068a256220ce90064179257fd65109c9e9ea5189144d78d22a029a8193c9a50