### PR TITLE
chore: add docker healthcheck (INFRA-786)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,9 @@ ENV DSP_META_LOG_FILTER="info,hyper=info"
 # set log output type
 ENV DSP_META_LOG_FMT="json"
 
+# enable periodic container health check
+HEALTHCHECK --start-period=60s --interval=60s --timeout=10s --retries=3 \
+  CMD curl -sS --fail "http://127.0.0.1:3000/health" | grep '^healthy$' || exit 1
+
 EXPOSE 3000
 ENTRYPOINT ["dsp-meta"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ COPY . .
 RUN cd web-frontend && yarn install && yarn run build --bundleConfigAsCjs
 
 FROM debian:bookworm-slim AS runtime
+# install curl
+RUN apt-get update && apt-get install --no-install-recommends -y curl && \
+  rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+
 # add data
 COPY ./data /data
 


### PR DESCRIPTION
Adding a healthcheck to improve reliability.

Old image size: 85MB
New image size: 97MB