### PR TITLE
data: Add dsp-app data link to nietzsche-me (DEV-6293)

### DIFF
--- a/data/json/nietzsche-me.json
+++ b/data/json/nietzsche-me.json
@@ -72,6 +72,12 @@
     "url": {
       "__type": "URL",
       "type": "URL",
+      "url": "https://app.dasch.swiss/project/bduDoIi8ShmgHXOAten_Ww",
+      "text": "Discover Project Data"
+    },
+    "secondaryURL": {
+      "__type": "URL",
+      "type": "URL",
       "url": "https://nietzsche.philhist.unibas.ch",
       "text": "External Project Website"
     },


### PR DESCRIPTION
## Summary

The `nietzsche-me` project (shortcode `0866`) is now live on dsp-app at
https://app.dasch.swiss/project/bduDoIi8ShmgHXOAten_Ww. This adds the
dsp-app link as the primary `url` on the project entry and moves the
existing external project website to `secondaryURL`, following the same
pattern used for `biz.json`.

## Change

On `data/json/nietzsche-me.json`:
- `project.url` → `https://app.dasch.swiss/project/bduDoIi8ShmgHXOAten_Ww` (`Discover Project Data`)
- `project.secondaryURL` → `https://nietzsche.philhist.unibas.ch` (`External Project Website`)

## Linear

[DEV-6293](https://linear.app/dasch/issue/DEV-6293)

## Test plan
- [x] `python3 -c "import json; json.load(open('data/json/nietzsche-me.json'))"` parses cleanly
- [ ] Reviewer verifies both links render on meta.dasch.swiss/projects/0866 after deploy

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>